### PR TITLE
Fix : env problems that lead to complie failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 **/devel/*
 **/PCD/*
 **/.cache/*
+.vscode/    
+data/
+log/
 result/
 utils/test_parallel.py
 environment/.cache/*
@@ -16,7 +19,6 @@ draw.py
 *.log
 
 *debug*
-utils/
 scripts/cpp/log
 scripts/cpp/trajlo
 scripts/log

--- a/Environment/.gitignore
+++ b/Environment/.gitignore
@@ -1,1 +1,4 @@
 environment/.catkin_workspace
+build/
+devel/
+log/

--- a/Environment/process_module/CMakeLists.txt
+++ b/Environment/process_module/CMakeLists.txt
@@ -8,7 +8,13 @@ find_package(yaml-cpp REQUIRED)
 find_package(Ceres REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(rosbag REQUIRED)
-find_package(Sophus REQUIRED)
+
+include_directories(
+    thirdparty/Sophus-1.22.10
+    thirdparty/ceres-solver-1.14.0
+    utils
+)
+# find_package(Sophus REQUIRED)
 include_directories(include ${CERES_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS} ${rosbag_INCLUDE_DIRS} ${SOPHUS_INCLUDE_DIRS})
 message(WARNING "sophus include dirs: ${SOPHUS_INCLUDE_DIRS}")
 message(WARNING "${CERES_INCLUDE_DIRS}")

--- a/Environment/process_module/include/basalt/spline/rd_spline.h
+++ b/Environment/process_module/include/basalt/spline/rd_spline.h
@@ -41,8 +41,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <basalt/spline/spline_common.h>
 #include <basalt/utils/assert.h>
 #include <basalt/utils/sophus_utils.hpp>
+#include <basalt/utils/eigen_utils.hpp>
 
-#include <Eigen/Dense>
+#include <Eigen/Eigen>
 
 #include <array>
 

--- a/Environment/process_module/include/basalt/utils/assert.h
+++ b/Environment/process_module/include/basalt/utils/assert.h
@@ -1,0 +1,97 @@
+/**
+BSD 3-Clause License
+
+This file is part of the Basalt project.
+https://gitlab.com/VladyslavUsenko/basalt-headers.git
+
+Copyright (c) 2019, Vladyslav Usenko and Nikolaus Demmel.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+@file
+@brief Assertions used in the project
+*/
+
+#pragma once
+
+#include <iostream>
+
+namespace basalt {
+
+#define UNUSED(x) (void)(x)
+
+inline void assertion_failed(char const* expr, char const* function,
+                             char const* file, long line) {
+  std::cerr << "***** Assertion (" << expr << ") failed in " << function
+            << ":\n"
+            << file << ':' << line << ":" << std::endl;
+  std::abort();
+}
+
+inline void assertion_failed_msg(char const* expr, char const* msg,
+                                 char const* function, char const* file,
+                                 long line) {
+  std::cerr << "***** Assertion (" << expr << ") failed in " << function
+            << ":\n"
+            << file << ':' << line << ": " << msg << std::endl;
+  std::abort();
+}
+}  // namespace basalt
+
+#define BASALT_LIKELY(x) __builtin_expect(x, 1)
+
+#if defined(BASALT_DISABLE_ASSERTS)
+
+#define BASALT_ASSERT(expr) ((void)0)
+
+#define BASALT_ASSERT_MSG(expr, msg) ((void)0)
+
+#define BASALT_ASSERT_STREAM(expr, msg) ((void)0)
+
+#else
+
+#define BASALT_ASSERT(expr)                                               \
+  (BASALT_LIKELY(!!(expr))                                                \
+       ? ((void)0)                                                        \
+       : ::basalt::assertion_failed(#expr, __PRETTY_FUNCTION__, __FILE__, \
+                                    __LINE__))
+
+#define BASALT_ASSERT_MSG(expr, msg)                                     \
+  (BASALT_LIKELY(!!(expr))                                               \
+       ? ((void)0)                                                       \
+       : ::basalt::assertion_failed_msg(#expr, msg, __PRETTY_FUNCTION__, \
+                                        __FILE__, __LINE__))
+
+#define BASALT_ASSERT_STREAM(expr, msg)                                    \
+  (BASALT_LIKELY(!!(expr))                                                 \
+       ? ((void)0)                                                         \
+       : (std::cerr << msg << std::endl,                                   \
+          ::basalt::assertion_failed(#expr, __PRETTY_FUNCTION__, __FILE__, \
+                                     __LINE__)))
+
+#endif

--- a/Environment/process_module/include/basalt/utils/eigen_utils.hpp
+++ b/Environment/process_module/include/basalt/utils/eigen_utils.hpp
@@ -1,0 +1,65 @@
+/**
+BSD 3-Clause License
+
+This file is part of the Basalt project.
+https://gitlab.com/VladyslavUsenko/basalt-headers.git
+
+Copyright (c) 2019, Vladyslav Usenko and Nikolaus Demmel.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+@file
+@brief Definition of the standard containers with Eigen allocator.
+*/
+
+#pragma once
+
+#include <deque>
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+#include "Eigen/Dense"
+
+namespace Eigen {
+
+template <typename T>
+using aligned_vector = std::vector<T, Eigen::aligned_allocator<T>>;
+
+template <typename T>
+using aligned_deque = std::deque<T, Eigen::aligned_allocator<T>>;
+
+template <typename K, typename V>
+using aligned_map = std::map<K, V, std::less<K>,
+                             Eigen::aligned_allocator<std::pair<K const, V>>>;
+
+template <typename K, typename V>
+using aligned_unordered_map =
+    std::unordered_map<K, V, std::hash<K>, std::equal_to<K>,
+                       Eigen::aligned_allocator<std::pair<K const, V>>>;
+
+}  // namespace Eigen

--- a/Environment/process_module/include/basalt/utils/sophus_utils.hpp
+++ b/Environment/process_module/include/basalt/utils/sophus_utils.hpp
@@ -1,0 +1,252 @@
+/*
+ * This file is modified from the Basalt project.
+ * https://gitlab.com/VladyslavUsenko/basalt-headers.git
+ * which is under BSD 3-Clause License.
+ * Copyright (c) 2019, Vladyslav Usenko and Nikolaus Demmel.
+ * */
+
+#pragma once
+
+#include "sophus/se3.hpp"
+
+namespace Sophus {
+
+template <typename Scalar>
+SOPHUS_FUNC inline typename SE3<Scalar>::Tangent se3_logd(
+    const SE3<Scalar> &se3) {
+  typename SE3<Scalar>::Tangent upsilon_omega;
+  upsilon_omega.template tail<3>() = se3.so3().log();
+  upsilon_omega.template head<3>() = se3.translation();
+
+  return upsilon_omega;
+}
+
+template <typename Derived>
+SOPHUS_FUNC inline SE3<typename Derived::Scalar> se3_expd(
+    const Eigen::MatrixBase<Derived> &upsilon_omega) {
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Derived, 6);
+
+  using Scalar = typename Derived::Scalar;
+
+  return SE3<Scalar>(SO3<Scalar>::exp(upsilon_omega.template tail<3>()),
+                     upsilon_omega.template head<3>());
+}
+
+template <typename Derived1, typename Derived2>
+SOPHUS_FUNC inline void rightJacobianSO3(
+    const Eigen::MatrixBase<Derived1> &phi,
+    const Eigen::MatrixBase<Derived2> &J_phi) {
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived1);
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived2);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Derived1, 3);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Derived2, 3, 3);
+
+  using Scalar = typename Derived1::Scalar;
+
+  using std::cos;
+  using std::sin;
+  using std::sqrt;
+
+  Eigen::MatrixBase<Derived2> &J =
+      const_cast<Eigen::MatrixBase<Derived2> &>(J_phi);
+
+  Scalar phi_norm2 = phi.squaredNorm();
+  Eigen::Matrix<Scalar, 3, 3> phi_hat = Sophus::SO3<Scalar>::hat(phi);
+  Eigen::Matrix<Scalar, 3, 3> phi_hat2 = phi_hat * phi_hat;
+
+  J.setIdentity();
+
+  if (phi_norm2 > Sophus::Constants<Scalar>::epsilon()) {
+    Scalar phi_norm = sqrt(phi_norm2);
+    Scalar phi_norm3 = phi_norm2 * phi_norm;
+
+    J -= phi_hat * (1 - cos(phi_norm)) / phi_norm2;
+    J += phi_hat2 * (phi_norm - sin(phi_norm)) / phi_norm3;
+  } else {
+    // Taylor expansion around 0
+    J -= phi_hat / 2;
+    J += phi_hat2 / 6;
+  }
+}
+
+template <typename Derived1, typename Derived2>
+SOPHUS_FUNC inline void rightJacobianInvSO3(
+    const Eigen::MatrixBase<Derived1> &phi,
+    const Eigen::MatrixBase<Derived2> &J_phi) {
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived1);
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived2);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Derived1, 3);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Derived2, 3, 3);
+
+  using Scalar = typename Derived1::Scalar;
+
+  using std::cos;
+  using std::sin;
+  using std::sqrt;
+
+  Eigen::MatrixBase<Derived2> &J =
+      const_cast<Eigen::MatrixBase<Derived2> &>(J_phi);
+
+  Scalar phi_norm2 = phi.squaredNorm();
+  Eigen::Matrix<Scalar, 3, 3> phi_hat = Sophus::SO3<Scalar>::hat(phi);
+  Eigen::Matrix<Scalar, 3, 3> phi_hat2 = phi_hat * phi_hat;
+
+  J.setIdentity();
+  J += phi_hat / 2;
+
+  if (phi_norm2 > Sophus::Constants<Scalar>::epsilon()) {
+    Scalar phi_norm = sqrt(phi_norm2);
+
+    // We require that the angle is in range [0, pi]. We check if we are close
+    // to pi and apply a Taylor expansion to scalar multiplier of phi_hat2.
+    // Technically, log(exp(phi)exp(epsilon)) is not continuous / differentiable
+    // at phi=pi, but we still aim to return a reasonable value for all valid
+    // inputs.
+    //    BASALT_ASSERT(phi_norm <= M_PI +
+    //    Sophus::Constants<Scalar>::epsilon());
+
+    if (phi_norm < M_PI - Sophus::Constants<Scalar>::epsilonSqrt()) {
+      // regular case for range (0,pi)
+      J += phi_hat2 * (1 / phi_norm2 -
+                       (1 + cos(phi_norm)) / (2 * phi_norm * sin(phi_norm)));
+    } else {
+      // 0th-order Taylor expansion around pi
+      J += phi_hat2 / (M_PI * M_PI);
+    }
+  } else {
+    // Taylor expansion around 0
+    J += phi_hat2 / 12;
+  }
+}
+
+template <typename Derived1, typename Derived2>
+SOPHUS_FUNC inline void leftJacobianSO3(
+    const Eigen::MatrixBase<Derived1> &phi,
+    const Eigen::MatrixBase<Derived2> &J_phi) {
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived1);
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived2);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Derived1, 3);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Derived2, 3, 3);
+
+  using Scalar = typename Derived1::Scalar;
+
+  using std::cos;
+  using std::sin;
+  using std::sqrt;
+
+  Eigen::MatrixBase<Derived2> &J =
+      const_cast<Eigen::MatrixBase<Derived2> &>(J_phi);
+
+  Scalar phi_norm2 = phi.squaredNorm();
+  Eigen::Matrix<Scalar, 3, 3> phi_hat = Sophus::SO3<Scalar>::hat(phi);
+  Eigen::Matrix<Scalar, 3, 3> phi_hat2 = phi_hat * phi_hat;
+
+  J.setIdentity();
+
+  if (phi_norm2 > Sophus::Constants<Scalar>::epsilon()) {
+    Scalar phi_norm = sqrt(phi_norm2);
+    Scalar phi_norm3 = phi_norm2 * phi_norm;
+
+    J += phi_hat * (1 - cos(phi_norm)) / phi_norm2;
+    J += phi_hat2 * (phi_norm - sin(phi_norm)) / phi_norm3;
+  } else {
+    // Taylor expansion around 0
+    J += phi_hat / 2;
+    J += phi_hat2 / 6;
+  }
+}
+
+template <typename Derived1, typename Derived2>
+SOPHUS_FUNC inline void leftJacobianInvSO3(
+    const Eigen::MatrixBase<Derived1> &phi,
+    const Eigen::MatrixBase<Derived2> &J_phi) {
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived1);
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived2);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Derived1, 3);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Derived2, 3, 3);
+
+  using Scalar = typename Derived1::Scalar;
+
+  using std::cos;
+  using std::sin;
+  using std::sqrt;
+
+  Eigen::MatrixBase<Derived2> &J =
+      const_cast<Eigen::MatrixBase<Derived2> &>(J_phi);
+
+  Scalar phi_norm2 = phi.squaredNorm();
+  Eigen::Matrix<Scalar, 3, 3> phi_hat = Sophus::SO3<Scalar>::hat(phi);
+  Eigen::Matrix<Scalar, 3, 3> phi_hat2 = phi_hat * phi_hat;
+
+  J.setIdentity();
+  J -= phi_hat / 2;
+
+  if (phi_norm2 > Sophus::Constants<Scalar>::epsilon()) {
+    Scalar phi_norm = sqrt(phi_norm2);
+
+    // We require that the angle is in range [0, pi]. We check if we are close
+    // to pi and apply a Taylor expansion to scalar multiplier of phi_hat2.
+    // Technically, log(exp(phi)exp(epsilon)) is not continuous / differentiable
+    // at phi=pi, but we still aim to return a reasonable value for all valid
+    // inputs.
+    //    BASALT_ASSERT(phi_norm <= M_PI +
+    //    Sophus::Constants<Scalar>::epsilon());
+
+    if (phi_norm < M_PI - Sophus::Constants<Scalar>::epsilonSqrt()) {
+      // regular case for range (0,pi)
+      J += phi_hat2 * (1 / phi_norm2 -
+                       (1 + cos(phi_norm)) / (2 * phi_norm * sin(phi_norm)));
+    } else {
+      // 0th-order Taylor expansion around pi
+      J += phi_hat2 / (M_PI * M_PI);
+    }
+  } else {
+    // Taylor expansion around 0
+    J += phi_hat2 / 12;
+  }
+}
+
+template <typename Derived1, typename Derived2>
+SOPHUS_FUNC inline void rightJacobianSE3Decoupled(
+    const Eigen::MatrixBase<Derived1> &phi,
+    const Eigen::MatrixBase<Derived2> &J_phi) {
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived1);
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived2);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Derived1, 6);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Derived2, 6, 6);
+
+  using Scalar = typename Derived1::Scalar;
+
+  Eigen::MatrixBase<Derived2> &J =
+      const_cast<Eigen::MatrixBase<Derived2> &>(J_phi);
+
+  J.setZero();
+
+  Eigen::Matrix<Scalar, 3, 1> omega = phi.template tail<3>();
+  rightJacobianSO3(omega, J.template bottomRightCorner<3, 3>());
+  J.template topLeftCorner<3, 3>() =
+      Sophus::SO3<Scalar>::exp(omega).inverse().matrix();
+}
+
+template <typename Derived1, typename Derived2>
+SOPHUS_FUNC inline void rightJacobianInvSE3Decoupled(
+    const Eigen::MatrixBase<Derived1> &phi,
+    const Eigen::MatrixBase<Derived2> &J_phi) {
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived1);
+  EIGEN_STATIC_ASSERT_FIXED_SIZE(Derived2);
+  EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Derived1, 6);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Derived2, 6, 6);
+
+  using Scalar = typename Derived1::Scalar;
+
+  Eigen::MatrixBase<Derived2> &J =
+      const_cast<Eigen::MatrixBase<Derived2> &>(J_phi);
+
+  J.setZero();
+
+  Eigen::Matrix<Scalar, 3, 1> omega = phi.template tail<3>();
+  rightJacobianInvSO3(omega, J.template bottomRightCorner<3, 3>());
+  J.template topLeftCorner<3, 3>() = Sophus::SO3<Scalar>::exp(omega).matrix();
+}
+}  // namespace Sophus

--- a/Environment/process_module/include/factor/mocap_pose_factor.hpp
+++ b/Environment/process_module/include/factor/mocap_pose_factor.hpp
@@ -6,7 +6,7 @@
 #include <ceres/ceres.h>
 #include <ceres/rotation.h>
 #include <Eigen/Core>
-#include <utils/imu_data.h>
+#include <imu_data.h>
 #include <sophus/so3.hpp>
 
 namespace estimator {

--- a/Environment/process_module/utils/imu_data.h
+++ b/Environment/process_module/utils/imu_data.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#define FMT_HEADER_ONLY
+
+#include <Eigen/Core>
+#include <sophus/se3.hpp>
+#include <sophus/so3.hpp>
+
+static const double GRAVITY_NORM = -9.80;
+
+using SO3d = Sophus::SO3<double>;
+using SE3d = Sophus::SE3<double>;
+
+struct IMUData {
+  double timestamp;
+  Eigen::Matrix<double, 3, 1> gyro;
+  Eigen::Matrix<double, 3, 1> accel;
+  SO3d orientation;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct IMUBias {
+  Eigen::Vector3d gyro_bias;
+  Eigen::Vector3d accel_bias;
+};
+
+struct IMUState {
+  double timestamp;
+  Eigen::Vector3d p;
+  Eigen::Vector3d v;
+  Eigen::Quaterniond q;
+  IMUBias bias;
+  Eigen::Vector3d g;
+  Eigen::Quaterniond gt_q;
+};
+
+struct PoseData {
+  PoseData()
+      : timestamp(0),
+        position(Eigen::Vector3d(0, 0, 0)),
+        orientation(SO3d(Eigen::Quaterniond::Identity())) {}
+
+  double timestamp;
+  Eigen::Vector3d position;
+  SO3d orientation;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};


### PR DESCRIPTION
### Issue：basic environment 
1. pytorch install
https://pytorch.org/get-started/previous-versions/
2. `sudo apt-get install libglfw3 libglfw3-dev`
3. `pip install catkin_pkg`
4.  navidia-diver
> #### [Issue:  Torch importError: /home/zjy/miniconda3/envs/L2Calib/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so: undefined symbol: iJIT_NotifyEvent ](https://github.com/pytorch/pytorch/issues/123097)

5. mkl 2024.0.0 （higher mkl version leads to pytorch import error）



### Issue : lack of .h files which lead to complie failed
1. /home/zjy/code/hw/learn-to-calibrate/Environment/process_module/include/factor/mocap_pose_factor.hpp:9:10: fatal error: imu_data.h: No such file or directory
    9 | #include <imu_data.h>
      |          ^~~~~~~~~~~~
compilation terminated.

2. /home/zjy/code/hw/learn-to-calibrate/Environment/process_module/include/basalt/spline/rd_spline.h:42:10: fatal error: basalt/utils/assert.h: No such file or directory
   42 | #include <basalt/utils/assert.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.

6. home/zjy/code/hw/learn-to-calibrate/Environment/process_module/include/basalt/spline/rd_spline.h:44:10: fatal error: basalt/utils/eigen_utils.hpp: No such file or directory
   44 | #include <basalt/utils/eigen_utils.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.

7. /home/zjy/code/hw/learn-to-calibrate/Environment/process_module/include/basalt/spline/rd_spline.h:43:10: fatal error: basalt/utils/sophus_utils.hpp: No such file or directory
   43 | #include <basalt/utils/sophus_utils.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.

### Solution
1. add imu_data.h file in /Environment/process_module/utils
2. add [assert.h](https://github.com/APRIL-ZJU/clins/blob/master/include/basalt/utils/assert.h) file in /Environment/process_module/include/basalt/utils/assert.h
3. add [eigen_utils and sophus_utils](https://github.com/APRIL-ZJU/clins/blob/master/include/basalt/utils/sophus_utils.hpp) in /basalt/utils
`cp ../Traj-LO/include/trajlo/utils/eigen_utils.hpp include/basalt/utils`
`cp ../Traj-LO/include/trajlo/utils/sophus_utils.hpp include/basalt/utils`

### Issue: error: ‘aligned_deque’ in namespace ‘Eigen’ does not name a template type
### Solution
modify the following #include directives at the top of the rd_spline.h file:
Location: /learn-to-calibrate/Environment/process_module/include/basalt/spline/rd_spline.h
from:
```
#include <basalt/spline/spline_common.h>
#include <basalt/utils/assert.h>
#include <basalt/utils/sophus_utils.hpp>
#include <Eigen/Dense>
#include <array>
```
to:
```
#include <basalt/spline/spline_common.h>
#include <basalt/utils/assert.h>
#include <basalt/utils/sophus_utils.hpp>
#include <basalt/utils/eigen_utils.hpp>
#include <Eigen/Eigen>
#include <array>
```

### Issue: thirdparty file import error
/home/zjy/code/hw/learn-to-calibrate/Environment/process_module/utils/imu_data.h:6:10: fatal error: sophus/se3.hpp: No such file or directory
    6 | #include <sophus/se3.hpp>
      |          ^~~~~~~~~~~~~~~~
compilation terminated.

### Solution
Location: /learn-to-calibrate/Environment/process_module/CMakeLists.txt
```
include_directories(
    thirdparty/Sophus-1.22.10
    thirdparty/ceres-solver-1.14.0
    utils
)
# find_package(Sophus REQUIRED)
```

### Results
Compilation successful,  code runs correctly.

